### PR TITLE
fix: fixed release config so manifest.json and /dist are now committe…

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -5,16 +5,38 @@
             {
                 "preset": "eslint",
                 "releaseRules": [
-                    { "tag": "breaking", "release": "major" },
-                    { "tag": "fix", "release": "patch" },
-                    { "tag": "update", "release": "minor" },
-                    { "tag": "new", "release": "minor" },
-                    { "tag": "docs", "release": "patch" },
-                    { "scope": "chore", "release": false }
-                  ],
-                  "parserOpts": {
-                    "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
-                  }
+                    {
+                        "tag": "breaking",
+                        "release": "major"
+                    },
+                    {
+                        "tag": "fix",
+                        "release": "patch"
+                    },
+                    {
+                        "tag": "update",
+                        "release": "minor"
+                    },
+                    {
+                        "tag": "new",
+                        "release": "minor"
+                    },
+                    {
+                        "tag": "docs",
+                        "release": "patch"
+                    },
+                    {
+                        "scope": "chore",
+                        "release": false
+                    }
+                ],
+                "parserOpts": {
+                    "noteKeywords": [
+                        "BREAKING CHANGE",
+                        "BREAKING CHANGES",
+                        "BREAKING"
+                    ]
+                }
             }
         ],
         [
@@ -28,10 +50,17 @@
             {
                 "preset": "eslint",
                 "parserOpts": {
-                "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
+                    "noteKeywords": [
+                        "BREAKING CHANGE",
+                        "BREAKING CHANGES",
+                        "BREAKING"
+                    ]
                 },
                 "writerOpts": {
-                    "commitsSort": ["subject", "scope"]
+                    "commitsSort": [
+                        "subject",
+                        "scope"
+                    ]
                 }
             }
         ],
@@ -47,8 +76,8 @@
             {
                 "assets": [
                     "package.json",
-                    "public/manifest.json",
-                    "build"
+                    "manifest.json",
+                    "dist"
                 ],
                 "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
             }
@@ -65,5 +94,7 @@
             }
         ]
     ],
-    "branches": ["main"]
+    "branches": [
+        "main"
+    ]
 }

--- a/bin/build_release
+++ b/bin/build_release
@@ -17,9 +17,7 @@ echo $NOTES >> release.txt
 
 # update manifest version
 echo "Bump the version in manifest.json to $VERSION... ✅"
-head manifest.json
 sed -i "s|\(\"version\": \)\(.*\),|\1\"$VERSION\",|g" manifest.json
-head manifest.json
 
 # Just creating a folder to dump our release in.
 echo "Create tmp releases dir... ✅"


### PR DESCRIPTION
…d in the release pipeline

The .releaserc file was still configured for webpack targeting /public/manifest.json and /build in the git commit stage.  The config was updated to reflect manifest.json in the root and /dist as the output folder.